### PR TITLE
fix : targetSdkVersion을 35로 업데이트 (Google Play 정책 대응)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -107,6 +107,9 @@ module.exports = {
           android: {
             usesCleartextTraffic: true,
             newArchEnabled: true,
+            compileSdkVersion: 35,
+            targetSdkVersion: 35,
+            buildToolsVersion: '35.0.0',
           },
           ios: {
             newArchEnabled: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remind",
-  "version": "1.8.11",
+  "version": "1.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remind",
-      "version": "1.8.11",
+      "version": "1.8.12",
       "hasInstallScript": true,
       "dependencies": {
         "@amplitude/analytics-react-native": "^1.4.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remind",
-  "version": "1.8.11",
+  "version": "1.8.12",
   "scripts": {
     "start": "expo start --dev-client",
     "android": "expo run:android",


### PR DESCRIPTION
Google Play가 요구하는 최소 targetSdkVersion 35 대응을 위해 expo-build-properties에서 targetSdkVersion, compileSdkVersion, buildToolsVersion을 35로 업데이트